### PR TITLE
fix_rank for sweep line

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-booleanop"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Bodo Junglas <junglas@objectcode.de>"]
 edition = "2018"
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
-geo-types = { version = "0.5.0", default-features = false }
+geo-types = { version = "0.6.0", default-features = false }
 num-traits = "0.2"
 robust = "0.1"
 float_next_after = "0.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,6 +14,7 @@ geo-types = { version = "0.6.0", default-features = false }
 num-traits = "0.2"
 robust = "0.1"
 float_next_after = "0.1"
+array_stump = { git = "https://github.com/daef/rust-array-stump", rev = "d2ca89804d0d7026484a461b16280b2cc503d4d7" }
 
 [dev-dependencies]
 rand = "0.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,9 @@ geo-types = { version = "0.6.0", default-features = false }
 num-traits = "0.2"
 robust = "0.1"
 float_next_after = "0.1"
-array_stump = { git = "https://github.com/daef/rust-array-stump", rev = "d2ca89804d0d7026484a461b16280b2cc503d4d7" }
+array_stump = { git = "https://github.com/daef/rust-array-stump", rev = "16dd59cd0e556fb66841dda4564a836bb8cfa502" }
+# array_stump = { path = "../../rust-array-stump/lib" }
+by_address = "1.0.4"
 
 [dev-dependencies]
 rand = "0.3"

--- a/lib/src/boolean/compare_segments.rs
+++ b/lib/src/boolean/compare_segments.rs
@@ -92,6 +92,9 @@ where
                 // left and right endpoints. I think in order to properly support self-overlapping
                 // segments we must return Ordering::Equal if and only if segments are the same
                 // by identity (the Rc::ptr_eq above).
+                if se_old_l.contour_id == se_new_l.contour_id {
+                    return Ordering::Equal;
+                }
                 less_if(se_old_l.contour_id < se_new_l.contour_id)
             } else {
                 // Fallback to purely temporal-based comparison. Since `less_if` already

--- a/lib/src/boolean/subdivide_segments.rs
+++ b/lib/src/boolean/subdivide_segments.rs
@@ -99,6 +99,7 @@ where
                         println!("{{\"sePostPrevEvent\": {}}}", prev.to_json_debug());
                     }
                     possible_intersection(&prev, &next, event_queue);
+                    sweep_line.fix_rank_range(index_prev.unwrap(), index_next.unwrap());
                 }
 
                 #[cfg(feature = "debug-booleanop")]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-booleanop-tests"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Bodo Junglas <junglas@objectcode.de>"]
 edition = "2018"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 geo-booleanop = { path = "../lib", features = [] }   # add "debug-booleanop" for debugging
-geo = "0.13"
+geo = "0.14"
 
 # Note: It is crucial to enable arbitrary_precision on serde_json, otherwise
 # JSON parsing isn't exact.
-geojson = { version = "0.18", features = ["geo-types"] }
+geojson = { version = "0.19", features = ["geo-types"] }
 serde_json = { version = "1.0.44", features = ["arbitrary_precision"] }
 
 clap = "2.3.3"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2"
 glob = "0.3"
 pretty_assertions = "0.6"
 rand = "0.7.3"
+array_stump = { git = "https://github.com/daef/rust-array-stump", rev = "d2ca89804d0d7026484a461b16280b2cc503d4d7" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,6 @@ num-traits = "0.2"
 glob = "0.3"
 pretty_assertions = "0.6"
 rand = "0.7.3"
-array_stump = { git = "https://github.com/daef/rust-array-stump", rev = "d2ca89804d0d7026484a461b16280b2cc503d4d7" }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
I've implemented a call to fix_rank_range after inserting a start-event.

When I wanted to verify the code I've seen that a test in test_generic_test_cases fails.
But when I tried `cargo test` on master there were also failed tests.

Maybe you could take a look at the results?

And since you've also performance tested various changes in the past maybe you could have a look at execution times too :)